### PR TITLE
Handle Path in Base URL

### DIFF
--- a/java-client/src/main/java/energy/trolie/client/TrolieClientBuilder.java
+++ b/java-client/src/main/java/energy/trolie/client/TrolieClientBuilder.java
@@ -3,7 +3,6 @@ package energy.trolie.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import energy.trolie.client.exception.TrolieException;
 import energy.trolie.client.impl.MemoryETagStore;
 import energy.trolie.client.impl.TrolieClientImpl;
 import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
@@ -12,9 +11,7 @@ import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotSubscribe
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.HttpHost;
 
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +42,7 @@ public class TrolieClientBuilder {
 	 */
 	public static final int DEFAULT_BUFFER_SIZE = 4096;
 
-	private final HttpHost host;
+	private final TrolieHost host;
 	private final CloseableHttpClient httpClient;
 	private RequestConfig requestConfig;
 	private int bufferSize = DEFAULT_BUFFER_SIZE;
@@ -78,11 +75,7 @@ public class TrolieClientBuilder {
 			String baseUrl, 
 			CloseableHttpClient httpClient) {
 		super();
-		try {
-			this.host = HttpHost.create(baseUrl);
-		} catch (URISyntaxException e) {
-			throw new TrolieException(e);
-		}
+		this.host = new TrolieHost(baseUrl);
 		this.httpClient = httpClient;
 	}
 

--- a/java-client/src/main/java/energy/trolie/client/TrolieHost.java
+++ b/java-client/src/main/java/energy/trolie/client/TrolieHost.java
@@ -1,0 +1,29 @@
+package energy.trolie.client;
+
+import energy.trolie.client.exception.TrolieException;
+import lombok.Getter;
+import org.apache.hc.core5.http.HttpHost;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Getter
+public class TrolieHost {
+
+    private final HttpHost host;
+    private final String basePath;
+
+    public TrolieHost(String baseUrl) {
+        try {
+            URI uri = new URI(baseUrl);
+            this.host = HttpHost.create(uri);
+            this.basePath = uri.getPath();
+        } catch (URISyntaxException e) {
+            throw new TrolieException(e);
+        }
+    }
+
+    public boolean hasBasePath() {
+        return this.basePath != null;
+    }
+}

--- a/java-client/src/main/java/energy/trolie/client/impl/TrolieClientImpl.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/TrolieClientImpl.java
@@ -1,21 +1,10 @@
 package energy.trolie.client.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import energy.trolie.client.request.monitoringsets.MonitoringSetsReceiver;
-import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
-import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotReceiver;
-import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotSubscribedReceiver;
-import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotReceiver;
-import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotSubscribedReceiver;
-import energy.trolie.client.request.ratingproposals.ForecastRatingProposalUpdate;
-import energy.trolie.client.request.ratingproposals.RealTimeRatingProposalUpdate;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.core5.http.HttpHost;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import energy.trolie.client.TrolieClient;
 import energy.trolie.client.ETagStore;
+import energy.trolie.client.RequestSubscription;
+import energy.trolie.client.TrolieClient;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.impl.request.RequestSubscriptionInternal;
 import energy.trolie.client.impl.request.monitoringsets.DefaultMonitoringSetRequest;
 import energy.trolie.client.impl.request.monitoringsets.DefaultMonitoringSetSubscribedRequest;
@@ -29,7 +18,18 @@ import energy.trolie.client.impl.request.operatingsnapshots.RegionalForecastSnap
 import energy.trolie.client.impl.request.operatingsnapshots.RegionalForecastSubscribedSnapshotRequest;
 import energy.trolie.client.impl.request.operatingsnapshots.RegionalRealTimeSnapshotRequest;
 import energy.trolie.client.impl.request.operatingsnapshots.RegionalRealTimeSnapshotSubscribedRequest;
-import energy.trolie.client.RequestSubscription;
+import energy.trolie.client.request.monitoringsets.MonitoringSetsReceiver;
+import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
+import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotReceiver;
+import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotSubscribedReceiver;
+import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotReceiver;
+import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotSubscribedReceiver;
+import energy.trolie.client.request.ratingproposals.ForecastRatingProposalUpdate;
+import energy.trolie.client.request.ratingproposals.RealTimeRatingProposalUpdate;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -44,7 +44,7 @@ public class TrolieClientImpl implements TrolieClient {
 	private static final Logger logger = LoggerFactory.getLogger(TrolieClientImpl.class);
 
 	CloseableHttpClient httpClient;
-	HttpHost host;
+	TrolieHost host;
 	RequestConfig requestConfig;
 	int bufferSize;
 	ObjectMapper objectMapper;
@@ -55,7 +55,7 @@ public class TrolieClientImpl implements TrolieClient {
 	private final int forecastRatingsPollMs;
 	private final int monitoringSetPollMs;
 
-	public TrolieClientImpl(CloseableHttpClient httpClient, HttpHost host, RequestConfig requestConfig, int bufferSize,
+	public TrolieClientImpl(CloseableHttpClient httpClient, TrolieHost host, RequestConfig requestConfig, int bufferSize,
 							ObjectMapper objectMapper, ETagStore eTagStore, Map<String, String> httpHeaders,
 							int defaultIntervalMinutes,
 							int realTimeRatingsPollMs,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/AbstractStreamingGet.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/AbstractStreamingGet.java
@@ -2,6 +2,9 @@ package energy.trolie.client.impl.request;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.StreamingResponseReceiver;
+import energy.trolie.client.StreamingSubscribedResponseReceiver;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.exception.StreamingGetConnectionException;
 import energy.trolie.client.exception.StreamingGetException;
 import energy.trolie.client.exception.StreamingGetResponseException;
@@ -11,13 +14,10 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import energy.trolie.client.StreamingResponseReceiver;
-import energy.trolie.client.StreamingSubscribedResponseReceiver;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -40,7 +40,7 @@ public abstract class AbstractStreamingGet<T extends StreamingResponseReceiver> 
 	Logger logger = LoggerFactory.getLogger(AbstractStreamingGet.class);
 	
 	HttpClient httpClient;
-	HttpHost host;
+	TrolieHost host;
 	RequestConfig requestConfig;
 	int bufferSize;
 	ThreadPoolExecutor threadPoolExecutor;
@@ -63,7 +63,7 @@ public abstract class AbstractStreamingGet<T extends StreamingResponseReceiver> 
 	
 	protected AbstractStreamingGet(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,
@@ -119,7 +119,7 @@ public abstract class AbstractStreamingGet<T extends StreamingResponseReceiver> 
 	}
 	
 	protected HttpGet createRequest() throws URISyntaxException {
-		HttpGet get = new HttpGet(getPath());
+		HttpGet get = new HttpGet(getFullPath());
 		get.addHeader(HttpHeaders.ACCEPT, getContentType());
 		if (httpHeaders !=  null && !httpHeaders.isEmpty()) {
 			httpHeaders.forEach(get::addHeader);
@@ -133,7 +133,7 @@ public abstract class AbstractStreamingGet<T extends StreamingResponseReceiver> 
 		try {
 			
 			HttpGet get = createRequest();
-			httpClient.execute(host, get, createResponseHandler());
+			httpClient.execute(host.getHost(), get, createResponseHandler());
 		
 		} catch (IOException e) {
 			logger.error("I/O error initiating request",e);
@@ -165,6 +165,10 @@ public abstract class AbstractStreamingGet<T extends StreamingResponseReceiver> 
 			return false;
 		}
 		
+	}
+
+	protected String getFullPath() {
+		return host.hasBasePath() ? host.getBasePath() + getPath() : getPath();
 	}
 	
 }

--- a/java-client/src/main/java/energy/trolie/client/impl/request/AbstractStreamingSubscribedGet.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/AbstractStreamingSubscribedGet.java
@@ -1,19 +1,19 @@
 package energy.trolie.client.impl.request;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.StreamingSubscribedResponseReceiver;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.exception.StreamingGetHandlingException;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.ProtocolException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.StreamingSubscribedResponseReceiver;
 
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -44,7 +44,7 @@ public abstract class AbstractStreamingSubscribedGet<T extends StreamingSubscrib
 	
 	protected AbstractStreamingSubscribedGet(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/DefaultMonitoringSetRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/DefaultMonitoringSetRequest.java
@@ -1,12 +1,12 @@
 package energy.trolie.client.impl.request.monitoringsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
+import energy.trolie.client.impl.request.AbstractStreamingGet;
 import energy.trolie.client.request.monitoringsets.MonitoringSetsReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
-import energy.trolie.client.TrolieApiConstants;
-import energy.trolie.client.impl.request.AbstractStreamingGet;
 
 import java.io.InputStream;
 import java.util.Map;
@@ -19,7 +19,7 @@ public class DefaultMonitoringSetRequest extends AbstractStreamingGet<Monitoring
 
 	public DefaultMonitoringSetRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/DefaultMonitoringSetSubscribedRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/DefaultMonitoringSetSubscribedRequest.java
@@ -1,13 +1,13 @@
 package energy.trolie.client.impl.request.monitoringsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
+import energy.trolie.client.impl.request.AbstractStreamingSubscribedGet;
 import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.impl.request.AbstractStreamingSubscribedGet;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.io.InputStream;
 import java.util.Map;
@@ -20,7 +20,7 @@ public class DefaultMonitoringSetSubscribedRequest extends AbstractStreamingSubs
 
 	public DefaultMonitoringSetSubscribedRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/MonitoringSetsRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/MonitoringSetsRequest.java
@@ -1,14 +1,14 @@
 package energy.trolie.client.impl.request.monitoringsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
+import energy.trolie.client.impl.request.AbstractStreamingGet;
 import energy.trolie.client.request.monitoringsets.MonitoringSetsReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.URIBuilder;
-import energy.trolie.client.TrolieApiConstants;
-import energy.trolie.client.impl.request.AbstractStreamingGet;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -23,7 +23,7 @@ public class MonitoringSetsRequest extends AbstractStreamingGet<MonitoringSetsRe
 	
 	public MonitoringSetsRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/MonitoringSetsSubscribedRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/monitoringsets/MonitoringSetsSubscribedRequest.java
@@ -1,15 +1,15 @@
 package energy.trolie.client.impl.request.monitoringsets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.impl.request.AbstractStreamingSubscribedGet;
 import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.URIBuilder;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -24,7 +24,7 @@ public class MonitoringSetsSubscribedRequest extends AbstractStreamingSubscribed
 	
 	public MonitoringSetsSubscribedRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/ForecastSnapshotRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/ForecastSnapshotRequest.java
@@ -1,14 +1,14 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.impl.request.AbstractStreamingGet;
 import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.URIBuilder;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -27,7 +27,7 @@ public class ForecastSnapshotRequest extends AbstractStreamingGet<ForecastSnapsh
 	
 	public ForecastSnapshotRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/ForecastSnapshotSubscribedRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/ForecastSnapshotSubscribedRequest.java
@@ -1,15 +1,15 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.impl.request.AbstractStreamingSubscribedGet;
 import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotSubscribedReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.URIBuilder;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -24,7 +24,7 @@ public class ForecastSnapshotSubscribedRequest extends AbstractStreamingSubscrib
 	
 	public ForecastSnapshotSubscribedRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RealTimeSnapshotRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RealTimeSnapshotRequest.java
@@ -1,14 +1,14 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.impl.request.AbstractStreamingGet;
 import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.URIBuilder;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -24,7 +24,7 @@ public class RealTimeSnapshotRequest extends AbstractStreamingGet<RealTimeSnapsh
 	
 	public RealTimeSnapshotRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RealTimeSnapshotSubscribedRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RealTimeSnapshotSubscribedRequest.java
@@ -1,15 +1,15 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.impl.request.AbstractStreamingSubscribedGet;
 import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotSubscribedReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.URIBuilder;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -25,7 +25,7 @@ public class RealTimeSnapshotSubscribedRequest extends AbstractStreamingSubscrib
 	
 	public RealTimeSnapshotSubscribedRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalForecastSnapshotRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalForecastSnapshotRequest.java
@@ -1,11 +1,11 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.time.Instant;
 import java.util.Map;
@@ -17,7 +17,7 @@ public class RegionalForecastSnapshotRequest extends ForecastSnapshotRequest {
 
 	public RegionalForecastSnapshotRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalForecastSubscribedSnapshotRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalForecastSubscribedSnapshotRequest.java
@@ -1,12 +1,12 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotSubscribedReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.util.Map;
 
@@ -17,7 +17,7 @@ public class RegionalForecastSubscribedSnapshotRequest extends ForecastSnapshotS
 
     public RegionalForecastSubscribedSnapshotRequest(
             HttpClient httpClient,
-            HttpHost host,
+            TrolieHost host,
             RequestConfig requestConfig,
             int bufferSize,
             ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalRealTimeSnapshotRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalRealTimeSnapshotRequest.java
@@ -1,11 +1,11 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.util.Map;
 
@@ -16,7 +16,7 @@ public class RegionalRealTimeSnapshotRequest extends RealTimeSnapshotRequest {
 
 	public RegionalRealTimeSnapshotRequest(
 			HttpClient httpClient, 
-			HttpHost host, 
+			TrolieHost host,
 			RequestConfig requestConfig,
 			int bufferSize, 
 			ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalRealTimeSnapshotSubscribedRequest.java
+++ b/java-client/src/main/java/energy/trolie/client/impl/request/operatingsnapshots/RegionalRealTimeSnapshotSubscribedRequest.java
@@ -1,12 +1,12 @@
 package energy.trolie.client.impl.request.operatingsnapshots;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.ETagStore;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotSubscribedReceiver;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.core5.http.HttpHost;
-import energy.trolie.client.ETagStore;
-import energy.trolie.client.TrolieApiConstants;
 
 import java.util.Map;
 
@@ -17,7 +17,7 @@ public class RegionalRealTimeSnapshotSubscribedRequest extends RealTimeSnapshotS
 
     public RegionalRealTimeSnapshotSubscribedRequest(
             HttpClient httpClient,
-            HttpHost host,
+            TrolieHost host,
             RequestConfig requestConfig,
             int bufferSize,
             ObjectMapper objectMapper,

--- a/java-client/src/main/java/energy/trolie/client/request/ratingproposals/ForecastRatingProposalUpdate.java
+++ b/java-client/src/main/java/energy/trolie/client/request/ratingproposals/ForecastRatingProposalUpdate.java
@@ -2,23 +2,23 @@ package energy.trolie.client.request.ratingproposals;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.exception.TrolieException;
 import energy.trolie.client.impl.model.ratingproposals.ForecastPeriodBuilderImpl;
+import energy.trolie.client.impl.request.AbstractStreamingUpdate;
+import energy.trolie.client.model.ratingproposals.ForecastPeriodBuilder;
+import energy.trolie.client.model.ratingproposals.ForecastProposalHeader;
+import energy.trolie.client.model.ratingproposals.ForecastRatingPeriod;
+import energy.trolie.client.model.ratingproposals.ForecastRatingProposalStatus;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpPatch;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpHost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import energy.trolie.client.TrolieApiConstants;
-import energy.trolie.client.impl.request.AbstractStreamingUpdate;
-import energy.trolie.client.model.ratingproposals.ForecastPeriodBuilder;
-import energy.trolie.client.model.ratingproposals.ForecastProposalHeader;
-import energy.trolie.client.model.ratingproposals.ForecastRatingPeriod;
-import energy.trolie.client.model.ratingproposals.ForecastRatingProposalStatus;
 
 import java.time.Instant;
 import java.util.Map;
@@ -50,7 +50,7 @@ public class ForecastRatingProposalUpdate extends AbstractStreamingUpdate<Foreca
 	 * @param httpHeaders passed headers
 	 * @param defaultIntervalMinutes forecast interval minutes
 	 */
-	public ForecastRatingProposalUpdate(HttpClient httpClient, HttpHost host, RequestConfig requestConfig,
+	public ForecastRatingProposalUpdate(HttpClient httpClient, TrolieHost host, RequestConfig requestConfig,
 										int bufferSize, ObjectMapper objectMapper, Map<String, String> httpHeaders,
 										int defaultIntervalMinutes) {
 		super(httpClient, host, requestConfig, bufferSize, objectMapper, httpHeaders);
@@ -73,7 +73,7 @@ public class ForecastRatingProposalUpdate extends AbstractStreamingUpdate<Foreca
 
 	@Override
 	protected HttpUriRequestBase getRequest() {
-		return new HttpPatch(getPath());
+		return new HttpPatch(getFullPath());
 	}
 
 	@Override

--- a/java-client/src/main/java/energy/trolie/client/request/ratingproposals/RealTimeRatingProposalUpdate.java
+++ b/java-client/src/main/java/energy/trolie/client/request/ratingproposals/RealTimeRatingProposalUpdate.java
@@ -2,21 +2,21 @@ package energy.trolie.client.request.ratingproposals;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import energy.trolie.client.TrolieApiConstants;
+import energy.trolie.client.TrolieHost;
 import energy.trolie.client.exception.TrolieException;
+import energy.trolie.client.impl.request.AbstractStreamingUpdate;
+import energy.trolie.client.model.ratingproposals.ProposalHeader;
+import energy.trolie.client.model.ratingproposals.RealTimeRating;
+import energy.trolie.client.model.ratingproposals.RealTimeRatingProposalStatus;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpHost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import energy.trolie.client.TrolieApiConstants;
-import energy.trolie.client.impl.request.AbstractStreamingUpdate;
-import energy.trolie.client.model.ratingproposals.ProposalHeader;
-import energy.trolie.client.model.ratingproposals.RealTimeRating;
-import energy.trolie.client.model.ratingproposals.RealTimeRatingProposalStatus;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -43,7 +43,7 @@ public class RealTimeRatingProposalUpdate extends AbstractStreamingUpdate<RealTi
 	 * @param objectMapper Jackson object mapper
 	 * @param httpHeader mapped header list
 	 */
-	public RealTimeRatingProposalUpdate(HttpClient httpClient, HttpHost host, RequestConfig requestConfig,
+	public RealTimeRatingProposalUpdate(HttpClient httpClient, TrolieHost host, RequestConfig requestConfig,
 										int bufferSize, ObjectMapper objectMapper, Map<String, String> httpHeader) {
 		super(httpClient, host, requestConfig, bufferSize, objectMapper, httpHeader);
 	}
@@ -61,7 +61,7 @@ public class RealTimeRatingProposalUpdate extends AbstractStreamingUpdate<RealTi
 	@Override
 	protected HttpUriRequestBase getRequest() {
 		//only need to establish the HTTP method. headers/params are handled by base class 
-		return new HttpPost(getPath());
+		return new HttpPost(getFullPath());
 	}
 
 	@Override

--- a/java-client/src/test/java/energy/trolie/client/TrolieClientIT.java
+++ b/java-client/src/test/java/energy/trolie/client/TrolieClientIT.java
@@ -7,7 +7,28 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import energy.trolie.client.exception.StreamingGetException;
 import energy.trolie.client.exception.TrolieException;
 import energy.trolie.client.exception.TrolieServerException;
+import energy.trolie.client.impl.request.RequestSubscriptionInternal;
+import energy.trolie.client.model.common.DataProvenance;
+import energy.trolie.client.model.common.RatingValue;
+import energy.trolie.client.model.monitoringsets.MonitoringSet;
+import energy.trolie.client.model.operatingsnapshots.ForecastPeriodSnapshot;
+import energy.trolie.client.model.operatingsnapshots.ForecastSnapshotHeader;
+import energy.trolie.client.model.operatingsnapshots.RealTimeLimit;
+import energy.trolie.client.model.operatingsnapshots.RealTimeSnapshotHeader;
+import energy.trolie.client.model.ratingproposals.ForecastProposalHeader;
+import energy.trolie.client.model.ratingproposals.ForecastRatingPeriod;
+import energy.trolie.client.model.ratingproposals.ForecastRatingProposalStatus;
+import energy.trolie.client.model.ratingproposals.ProposalHeader;
+import energy.trolie.client.model.ratingproposals.RealTimeRating;
+import energy.trolie.client.model.ratingproposals.RealTimeRatingProposalStatus;
+import energy.trolie.client.request.monitoringsets.MonitoringSetsReceiver;
+import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
+import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotReceiver;
+import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotSubscribedReceiver;
+import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotReceiver;
 import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotSubscribedReceiver;
+import energy.trolie.client.request.ratingproposals.ForecastRatingProposalUpdate;
+import energy.trolie.client.request.ratingproposals.RealTimeRatingProposalUpdate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.HttpHostConnectException;
 import org.apache.hc.client5.http.classic.HttpClient;
@@ -36,27 +57,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import energy.trolie.client.impl.request.RequestSubscriptionInternal;
-import energy.trolie.client.model.common.DataProvenance;
-import energy.trolie.client.model.common.RatingValue;
-import energy.trolie.client.model.monitoringsets.MonitoringSet;
-import energy.trolie.client.model.operatingsnapshots.ForecastPeriodSnapshot;
-import energy.trolie.client.model.operatingsnapshots.ForecastSnapshotHeader;
-import energy.trolie.client.model.operatingsnapshots.RealTimeLimit;
-import energy.trolie.client.model.operatingsnapshots.RealTimeSnapshotHeader;
-import energy.trolie.client.model.ratingproposals.ForecastProposalHeader;
-import energy.trolie.client.model.ratingproposals.ForecastRatingPeriod;
-import energy.trolie.client.model.ratingproposals.ForecastRatingProposalStatus;
-import energy.trolie.client.model.ratingproposals.ProposalHeader;
-import energy.trolie.client.model.ratingproposals.RealTimeRating;
-import energy.trolie.client.model.ratingproposals.RealTimeRatingProposalStatus;
-import energy.trolie.client.request.monitoringsets.MonitoringSetsReceiver;
-import energy.trolie.client.request.monitoringsets.MonitoringSetsSubscribedReceiver;
-import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotReceiver;
-import energy.trolie.client.request.operatingsnapshots.ForecastSnapshotSubscribedReceiver;
-import energy.trolie.client.request.operatingsnapshots.RealTimeSnapshotReceiver;
-import energy.trolie.client.request.ratingproposals.ForecastRatingProposalUpdate;
-import energy.trolie.client.request.ratingproposals.RealTimeRatingProposalUpdate;
 
 import javax.net.ServerSocketFactory;
 import java.io.IOException;
@@ -199,7 +199,7 @@ public class TrolieClientIT {
 
 		HttpClientBuilder builder = HttpClientBuilder.create();
 
-		try (TrolieClient trolieClient = new TrolieClientBuilder(baseUri,builder.build()).build();) {
+		try (TrolieClient trolieClient = new TrolieClientBuilder(baseUri + "/test-path", builder.build()).build()) {
 
 			try (ForecastRatingProposalUpdate update = trolieClient.createForecastRatingProposalStreamingUpdate()) {
 


### PR DESCRIPTION
Fixes Issue #2.

TROLIE implementations may need to be accessed using a path, but the TrolieClientBuilder was failing to handle this. For example, the following line would throw an error: `new TrolieClientBuilder("https://hostname/trolie-path").build();`.

The TrolieClient was using just an HttpHost under the hood to handle the base URL, but HttpHost alone cannot handle base paths that apply to all requests.

This PR adds TrolieHost that acts as a wrapper around HttpHost and handles an optional path in the base URL. The TrolieClientBuilder API remains unchanged, and the TrolieHost class now handles parsing the base URL.