### PR TITLE
Update proposal status DTOs to match TROLIE 1.0 spec

### DIFF
--- a/java-client/src/main/java/energy/trolie/client/model/ratingproposals/ForecastRatingProposalStatus.java
+++ b/java-client/src/main/java/energy/trolie/client/model/ratingproposals/ForecastRatingProposalStatus.java
@@ -40,8 +40,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class ForecastRatingProposalStatus {
 
-    @JsonProperty("forecast-provider")
-    private DataProvenance forecastProvider;
+    @JsonProperty("source")
+    private DataProvenance source;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("begins")

--- a/java-client/src/main/java/energy/trolie/client/model/ratingproposals/RealTimeRatingProposalStatus.java
+++ b/java-client/src/main/java/energy/trolie/client/model/ratingproposals/RealTimeRatingProposalStatus.java
@@ -38,8 +38,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class RealTimeRatingProposalStatus {
 
-    @JsonProperty("forecast-provider")
-    private DataProvenance forecastProvider;
+    @JsonProperty("source")
+    private DataProvenance source;
 
     @JsonProperty("incomplete-obligation-count")
     private long incompleteObligationCount;


### PR DESCRIPTION
This fixes issue #8 by matching the proposal status objects with the TROLIE 1.0 Spec.