### PR TITLE
Fix content type for real time proposals

### DIFF
--- a/java-client/src/main/java/energy/trolie/client/TrolieApiConstants.java
+++ b/java-client/src/main/java/energy/trolie/client/TrolieApiConstants.java
@@ -56,7 +56,7 @@ public class TrolieApiConstants {
 	/**
 	 * Content type for real-time proposal status.
 	 */
-	public static final String CONTENT_TYPE_REALTIME_PROPOSAL = "application/vnd.trolie.rating-realtime-proposal-status.v1+json";
+	public static final String CONTENT_TYPE_REALTIME_PROPOSAL = "application/vnd.trolie.rating-realtime-proposal.v1+json";
 
 	/**
 	 * Content type for forecast limit snapshots


### PR DESCRIPTION
The real time proposal content type is incorrect which is preventing the SDK from submitting proposals.